### PR TITLE
Don't need swap anymore.

### DIFF
--- a/include/nativehelper/UniquePtr.h
+++ b/include/nativehelper/UniquePtr.h
@@ -19,11 +19,6 @@
 
 #include <cstdlib> // For NULL.
 
-// This is a fake declaration of std::swap to avoid including <algorithm>
-namespace std {
-template <class T> void swap(T&, T&);
-}
-
 // Default deleter for pointer types.
 template <typename T>
 struct DefaultDelete {
@@ -83,11 +78,6 @@ public:
             D()(mPtr);
             mPtr = ptr;
         }
-    }
-
-    // Swap with another unique pointer.
-    void swap(UniquePtr<T>& other) {
-      std::swap(mPtr, other.mPtr);
     }
 
 private:


### PR DESCRIPTION
The declaration of std::swap here is inconsistent with the one in
libc++ (noexcept differences). Rather than worrying about keeping them
all consistent, just remove swap. It was only ever added for ART, and
ART now uses std::unique_ptr instead.

This was causing an ambiguous overload error in system/core with newer GCC.

Change-Id: I4cf4c41c5dda01a96915e8309af2f8be089d1a2a

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>